### PR TITLE
client: slow down retries and log errors

### DIFF
--- a/pkg/universe.dagger.io/package.json
+++ b/pkg/universe.dagger.io/package.json
@@ -1,7 +1,7 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "test": "bats --report-formatter junit --print-output-on-failure --jobs 4 $(find . -type f -name '*.bats' -not -path '*/node_modules/*')"
+    "test": "bats --report-formatter junit --print-output-on-failure --jobs 1 $(find . -type f -name '*.bats' -not -path '*/node_modules/*')"
   },
   "devDependencies": {
     "bats": "^1.5.0",

--- a/util/buildkitd/buildkitd.go
+++ b/util/buildkitd/buildkitd.go
@@ -228,10 +228,10 @@ func waitBuildkit(ctx context.Context) error {
 	// FIXME Does output "failed to wait: signal: broken pipe"
 	defer c.Close()
 
-	// Try to connect every 100ms up to 100 times (10 seconds total)
+	// Try to connect every 1s up to 10 times (10 seconds total)
 	const (
-		retryPeriod   = 100 * time.Millisecond
-		retryAttempts = 100
+		retryPeriod   = 1000 * time.Millisecond
+		retryAttempts = 10
 	)
 
 	for retry := 0; retry < retryAttempts; retry++ {
@@ -239,6 +239,7 @@ func waitBuildkit(ctx context.Context) error {
 		if err == nil {
 			return nil
 		}
+		log.Ctx(ctx).Debug().Err(err).Msg("error connecting to buildkitd in retry loop")
 		time.Sleep(retryPeriod)
 	}
 	return errors.New("buildkit failed to respond")


### PR DESCRIPTION
This is an attempt to debug the GRPC errors we are getting when making
some early API calls to buildkit.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>