### PR TITLE
ci: use prod dagger binary in universe tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ core-integration: dagger # Run core integration tests
 # 	DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger-debug" yarn --cwd "./universe" test
 
 .PHONY: universe-test
-universe-test: dagger-debug # Run universe tests
+universe-test: dagger # Run universe tests
 	yarn --cwd "./pkg/universe.dagger.io" install
-	TESTDIR=$(UNIVERSE_TESTDIR) DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger-debug" yarn --cwd "./pkg/universe.dagger.io" test
+	TESTDIR=$(UNIVERSE_TESTDIR) DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger" yarn --cwd "./pkg/universe.dagger.io" test
 
 .PHONY: doc-test
 doc-test: dagger-debug # Test docs


### PR DESCRIPTION
For reasons that are not clear to me at this time, when using the
dagger-debug binary to run universe tests, the new yarn test is
incredibly slow and usually times out after 30 minutes. But when using
the default dagger binary, it's relatively fast.

This needs to be understood better, but for now, running the universe
tests with the default binary will unblock our CI (which currently fails
on this yarn test consistently).

Signed-off-by: Erik Sipsma <erik@sipsma.dev>